### PR TITLE
大佬，发现您的项目引入了org.apache.logging.log4j:log4j-core@2.15.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>top.xinsin</groupId>
@@ -59,7 +57,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.17.1</version>
         </dependency>
 
         <!--log4j api依赖-->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Log4j 代码问题漏洞
缺陷组件：org.apache.logging.log4j:log4j-core@2.15.0
漏洞编号：CVE-2021-45046
漏洞描述：Apache Log4j是美国阿帕奇（Apache）基金会的一款基于Java的开源日志记录工具。
Apache Log4j 2.15.0版本存在代码问题漏洞，该漏洞源于当日志配置使用非默认模式布局和上下文查找或线程上下文映射模式使用 JNDI 查找模式制作恶意输入数据，从而导致拒绝服务攻击。
影响范围：[2.13.0, 2.16.0)
最小修复版本：2.17.1
缺陷组件引入路径：top.xinsin:lib-user@1.0-SNAPSHOT->org.apache.logging.log4j:log4j-core@2.15.0
```
另外我运行这个项目时，IDE的安全插件提示还有19个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p7f3a1